### PR TITLE
Fix the types path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React Native plugin for improving app security and threat monitoring on Android and iOS mobile devices.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/index.d.ts",
+  "types": "lib/typescript/src/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "scripts": {


### PR DESCRIPTION
# What's new
The `types` field in package.json is pointing to the wrong place. This change fixes it.

The built `lib` directory in fact looks like this. This is also true for the npm package.

![image](https://github.com/user-attachments/assets/72914c9e-6fd3-4abb-b435-3859b6fe330f)

# Resolved issues
* The types are resolved properly by the TS compiler.
