### PR TITLE
fix: use sdk versions from plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.1] - 2024-03-10
+
+- iOS SDK version:  6.8.0
+- Android SDK version: 14.0.1
+
+### React Native
+
+#### Fixed
+
+- Take Android targetSdkVersion, compileSdkVersion from plugin only
+
 ## [3.14.0] - 2024-03-05
 
 - iOS SDK version:  6.8.0

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,11 +40,11 @@ def getIntegerDefault(name) {
 }
 
 android {
-  compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
+  compileSdkVersion getIntegerDefault("compileSdkVersion")
 
   defaultConfig {
     minSdkVersion getIntegerDefault("minSdkVersion")
-    targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
+    targetSdkVersion getIntegerDefault("targetSdkVersion")
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
   }
   buildTypes {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freerasp-react-native",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "React Native plugin for improving app security and threat monitoring on Android and iOS mobile devices.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
# What's new
_Describe the PR shortly_

# PR checklist

## In-app checks:
- [ ] callbacks are received
- [ ] dev/prod switch works
- [ ] `README.md` is updated _(if applicable)_
- [ ] `expo` plugin is updated _(if applicable)_
- [ ] `example` app is working

## Pre-release checks:

- [ ] `CHANGELOG.md` is updated
- [ ] `package.json` version is increased
- [ ] `release` label is applied on PR

### To be checked by maintainers:

- [ ] freeRASP logs are received
- [ ] `sdkVersion` property in logs is correct
- [ ] `sdkPlatform` property in logs is correct

# Resolved issues
_list of issues resolved by this PR_
Fixes #106 , Fixes #107 