### PR TITLE
fix: install ios dependencies with install_modules_dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.4] - 2025-09-17
+
+- iOS SDK version: 6.12.1
+- Android SDK version: 16.0.4
+
+### React Native
+
+#### Fixed
+
+- iOS dependencies are now installed via `install_modules_dependencies` by default
+
 ## [4.2.3] - 2025-09-03
 
 - iOS SDK version: 6.12.1

--- a/freerasp-react-native.podspec
+++ b/freerasp-react-native.podspec
@@ -18,20 +18,25 @@ Pod::Spec.new do |s|
   s.xcconfig = { 'OTHER_LDFLAGS' => '-framework TalsecRuntime' }
   s.ios.vendored_frameworks = "ios/TalsecRuntime.xcframework"
   
-  s.dependency "React-Core"
-
-  # Don't install the dependencies when we run `pod install` in the old architecture.
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-        "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
+  # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
+  # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
+  if respond_to?(:install_modules_dependencies, true)
+    install_modules_dependencies(s)
+  else
+    s.dependency "React-Core"
+    # Don't install the dependencies when we run `pod install` in the old architecture.
+    if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
+      s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
+      s.pod_target_xcconfig    = {
+          "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+          "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
+      }
+      s.dependency "React-Codegen"
+      s.dependency "RCT-Folly"
+      s.dependency "RCTRequired"
+      s.dependency "RCTTypeSafety"
+      s.dependency "ReactCommon/turbomodule/core"
+    end
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freerasp-react-native",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "description": "React Native plugin for improving app security and threat monitoring on Android and iOS mobile devices.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
# What's new
_Describe the PR shortly_

# PR checklist

## In-app checks:
- [x] callbacks are received
- [x] dev/prod switch works
- [x] `README.md` is updated _(if applicable)_
- [x] `expo` plugin is updated _(if applicable)_
- [x] `example` app is working

## Pre-release checks:

- [x] `CHANGELOG.md` is updated
- [x] `package.json` version is increased
- [x] `release` label is applied on PR

### To be checked by maintainers:

- [x] freeRASP logs are received
- [x] `sdkVersion` property in logs is correct
- [x] `sdkPlatform` property in logs is correct

# Resolved issues
_list of issues resolved by this PR_

resolves #121 
