### PR TITLE
fix: add lazy initialization for rasp events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.2] - 2025-01-03
+
+- Android SDK version: 17.0.1
+- iOS SDK version: 6.13.0
+
+### React Native
+
+#### Fixed
+
+- Resolved potential NullPointerException when execution state events are being sent 
+
 ## [4.3.1] - 2025-12-16
 
 - Android SDK version: 17.0.1

--- a/android/src/main/java/com/freeraspreactnative/FreeraspReactNativeModule.kt
+++ b/android/src/main/java/com/freeraspreactnative/FreeraspReactNativeModule.kt
@@ -59,6 +59,7 @@ class FreeraspReactNativeModule(private val reactContext: ReactApplicationContex
   init {
     appReactContext = reactContext
     reactContext.addLifecycleEventListener(lifecycleListener)
+    initializeEventKeys()
   }
 
   @ReactMethod
@@ -87,6 +88,12 @@ class FreeraspReactNativeModule(private val reactContext: ReactApplicationContex
     } catch (e: Exception) {
       promise.reject("TalsecInitializationError", e.message, e)
     }
+  }
+
+  // Trigger lazy initialization of the freeRASP events
+  private fun initializeEventKeys() {
+    ThreatEvent.ALL_EVENTS
+    RaspExecutionStateEvent.ALL_EVENTS
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freerasp-react-native",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "React Native plugin for improving app security and threat monitoring on Android and iOS mobile devices.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
# What's new
_Describe the PR shortly_


# PR checklist

## In-app checks:
- [ ] callbacks are received
- [ ] dev/prod switch works
- [ ] `README.md` is updated _(if applicable)_
- [ ] `expo` plugin is updated _(if applicable)_
- [ ] `example` app is working

## Pre-release checks:

- [ ] `CHANGELOG.md` is updated
- [ ] `package.json` version is increased
- [ ] `release` label is applied on PR

### To be checked by maintainers:

- [ ] freeRASP logs are received
- [ ] `sdkVersion` property in logs is correct
- [ ] `sdkPlatform` property in logs is correct

# Resolved issues
_list of issues resolved by this PR_
resolves #133 